### PR TITLE
add text-to-image collection

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,8 +61,12 @@ app.post('/collections', asyncHandler(async (req, res) => {
   console.log('collections')
   res.status(200).json([
     {
-      slug: 'image-to-text',
+      slug: 'text-to-image',
       description: 'Models that generate images from text prompts'
+    },
+    {
+      slug: 'image-to-text',
+      description: 'Models that generate text from images'
     },
     {
       slug: 'audio-generation',


### PR DESCRIPTION
@fofr I think ChatGPT was getting tripped up because we didn't have the `text-to-image` collection available through this proxied API. This should take care of that!